### PR TITLE
Unionvms 4611

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBean.java
@@ -212,10 +212,10 @@ class SubscriptionServiceBean implements SubscriptionService {
     public SubscriptionDto createManual(@Valid @NotNull SubscriptionDto subscription) {
         SubscriptionEntity entity = mapper.mapDtoToEntity(subscription);
         setValidityPeriodForManualTrigger(entity);
-        entity.setHasAssets((entity.getAssets() != null && !entity.getAssets().isEmpty()) || (entity.getAssetGroups() != null && !entity.getAssetGroups().isEmpty()));
-        if (!entity.getAssets().isEmpty()) {
-            enrichNewAssets(entity.getAssets());
-        }
+        enrichNewAssets(entity.getAssets());
+        entity.setHasAreas(subscription.getAreas() != null && !subscription.getAreas().isEmpty());
+        entity.setHasAssets(subscription.getAssets() != null && !subscription.getAssets().isEmpty());
+        entity.setHasSenders(false);
         SubscriptionEntity saved = subscriptionDAO.createEntity(entity);
         sendAssetPageRetrievalMessages(saved);
         sendLogToAudit(mapToAuditLog(SUBSCRIPTION, AuditActionEnum.CREATE.name(), saved.getId().toString(), authenticationContext.getUserPrincipal().getName()));

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/filter/AreaFilterComponent.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/filter/AreaFilterComponent.java
@@ -1,0 +1,28 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.subscription.service.filter;
+
+import eu.europa.ec.fisheries.uvms.subscription.service.trigger.AssetAndSubscriptionData;
+import java.util.List;
+import java.util.stream.Stream;
+
+public interface AreaFilterComponent {
+
+    /**
+     * Filters AssetAndSubscriptionData by its assetEntity.guid for the given collection, by {@code subscription.areas},
+     * also will calculate a period to request (start and date) from the {@code subscription.output}.
+     *
+     * @param assetAndSubscriptionDataList To be filtered
+     * @return The filtered List<AssetAndSubscriptionData>
+     */
+    Stream<AssetAndSubscriptionData> filterAssetsBySubscriptionAreas(List<AssetAndSubscriptionData> assetAndSubscriptionDataList);
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/AssetAndSubscriptionData.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/AssetAndSubscriptionData.java
@@ -1,0 +1,25 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
+
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AssetEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AssetAndSubscriptionData {
+    private final AssetEntity assetEntity;
+    private final SubscriptionEntity subscription;
+    private final String occurrenceKeyData;
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractor.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractor.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import javax.xml.datatype.DatatypeFactory;
 
 import eu.europa.ec.fisheries.uvms.subscription.service.bean.SubscriptionFinder;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.asset.AssetSender;
 import eu.europa.ec.fisheries.uvms.subscription.service.util.DateTimeService;
 
@@ -29,8 +30,8 @@ public class ManualSubscriptionCommandFromMessageExtractor extends SubscriptionB
     public ManualSubscriptionCommandFromMessageExtractor(SubscriptionFinder subscriptionFinder,
                                                          TriggerCommandsFactory triggerCommandsFactory,
                                                          DatatypeFactory datatypeFactory,
-                                                         DateTimeService dateTimeService, AssetSender assetSender) {
-        super(subscriptionFinder, triggerCommandsFactory, datatypeFactory, dateTimeService, assetSender);
+                                                         DateTimeService dateTimeService, AssetSender assetSender, AreaFilterComponent areaFilterComponent) {
+        super(subscriptionFinder, triggerCommandsFactory, datatypeFactory, dateTimeService, assetSender, areaFilterComponent);
     }
 
     /**

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractor.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractor.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import javax.xml.datatype.DatatypeFactory;
 
 import eu.europa.ec.fisheries.uvms.subscription.service.bean.SubscriptionFinder;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.asset.AssetSender;
 import eu.europa.ec.fisheries.uvms.subscription.service.util.DateTimeService;
 
@@ -29,8 +30,8 @@ public class ScheduledSubscriptionCommandFromMessageExtractor extends Subscripti
     public ScheduledSubscriptionCommandFromMessageExtractor(SubscriptionFinder subscriptionFinder,
                                                             TriggerCommandsFactory triggerCommandsFactory,
                                                             DatatypeFactory datatypeFactory,
-                                                            DateTimeService dateTimeService, AssetSender assetSender) {
-        super(subscriptionFinder, triggerCommandsFactory, datatypeFactory, dateTimeService, assetSender);
+                                                            DateTimeService dateTimeService, AssetSender assetSender,AreaFilterComponent areaFilterComponent) {
+        super(subscriptionFinder, triggerCommandsFactory, datatypeFactory, dateTimeService, assetSender, areaFilterComponent);
     }
 
     /**

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionBasedCommandFromMessageExtractor.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionBasedCommandFromMessageExtractor.java
@@ -29,13 +29,12 @@ import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntit
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.search.SubscriptionSearchCriteria.SenderCriterion;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.AssetPageRetrievalMessage;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.asset.AssetSender;
 import eu.europa.ec.fisheries.uvms.subscription.service.util.DateTimeService;
 import eu.europa.ec.fisheries.wsdl.asset.types.VesselIdentifiersWithConnectIdHolder;
 import eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVesselIdentifier;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 /* Base abstract class for manual and scheduled subscriptions */
 public abstract class SubscriptionBasedCommandFromMessageExtractor implements SubscriptionCommandFromMessageExtractor {
@@ -53,16 +52,18 @@ public abstract class SubscriptionBasedCommandFromMessageExtractor implements Su
     private DatatypeFactory datatypeFactory;
     private DateTimeService dateTimeService;
     private AssetSender assetSender;
+    private AreaFilterComponent areaFilterComponent;
 
     public SubscriptionBasedCommandFromMessageExtractor(SubscriptionFinder subscriptionFinder,
                                                         TriggerCommandsFactory triggerCommandsFactory,
                                                         DatatypeFactory datatypeFactory,
-                                                        DateTimeService dateTimeService, AssetSender assetSender) {
+                                                        DateTimeService dateTimeService, AssetSender assetSender, AreaFilterComponent areaFilterComponent) {
         this.subscriptionFinder = subscriptionFinder;
         this.triggerCommandsFactory = triggerCommandsFactory;
         this.datatypeFactory = datatypeFactory;
         this.dateTimeService = dateTimeService;
         this.assetSender = assetSender;
+        this.areaFilterComponent = areaFilterComponent;
     }
 
     /**
@@ -90,9 +91,11 @@ public abstract class SubscriptionBasedCommandFromMessageExtractor implements Su
     }
 
     private Stream<Command> makeCommandsForSubscription(SubscriptionEntity subscription, List<AssetEntity> assets) {
-        return assets.stream()
+        List<AssetAndSubscriptionData> assetAndSubscriptionData = assets.stream()
                 .distinct()
-                .map(a -> new AssetAndSubscriptionData(a, subscription))
+                .map(makeAssetAndSubscriptionDataMapper(subscription))
+                .collect(Collectors.toList());
+        return areaFilterComponent.filterAssetsBySubscriptionAreas(assetAndSubscriptionData)
                 .map(this::makeTriggeredSubscriptionEntity)
                 .map(this::makeCommandForSubscription);
     }
@@ -194,12 +197,16 @@ public abstract class SubscriptionBasedCommandFromMessageExtractor implements Su
         );
     }
 
-    @Getter
-    @AllArgsConstructor
-    private static class AssetAndSubscriptionData {
-        private final AssetEntity assetEntity;
-        private final SubscriptionEntity subscription;
+    private Function<AssetEntity,AssetAndSubscriptionData> makeAssetAndSubscriptionDataMapper(SubscriptionEntity manualSubscription) {
+        return assetEntity -> {
+            String occurrenceKeyData = null;
+            if(manualSubscription.getOutput().getQueryPeriod() == null){
+                GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+                calendar.setTime(dateTimeService.getNowAsDate());
+                XMLGregorianCalendar xmlCalendar = datatypeFactory.newXMLGregorianCalendar(calendar);
+                occurrenceKeyData = xmlCalendar.toXMLFormat();
+            }
+            return new AssetAndSubscriptionData(assetEntity,manualSubscription,occurrenceKeyData);
+        };
     }
 }
-
-

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/DateTimeUtil.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/DateTimeUtil.java
@@ -1,0 +1,32 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.subscription.service.util;
+
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+public class DateTimeUtil {
+
+    /**
+     * Converts given date to ZonedDateTime
+     * @param date To be converted
+     * @return The converted ZonedDateTime
+     */
+    public static ZonedDateTime convertDateToZonedDateTime(Date date) {
+        GregorianCalendar calendarStartDate = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        calendarStartDate.setTime(date);
+        return calendarStartDate.toZonedDateTime();
+    }
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeService.java
@@ -1,0 +1,39 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.service.util;
+
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
+import java.time.ZonedDateTime;
+
+/**
+ * Subscription Date and time utilities.
+ * <p>
+ * This class abstracts the current time facilities of the system, to
+ * help with testing time-sensitive pieces of code.
+ */
+public interface SubscriptionDateTimeService {
+
+    /**
+     * Calculates the start date
+	 * @param output Will use its queryPeriod or history unit data
+     * @param endDate Will be used in case outputs queryPeriod is null
+     * @return The calculated start date
+     */
+	ZonedDateTime calculateStartDate(SubscriptionOutput output, ZonedDateTime endDate);
+
+	/**
+	 * Calculates the end date
+	 * @param output Will use its queryPeriods endDate
+	 * @param occurrence Will be used in case outputs queryPeriod is null
+	 * @return The calculated end date
+	 */
+	ZonedDateTime calculateEndDate(SubscriptionOutput output, String occurrence);
+
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeServiceImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.service.util;
+
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.xml.datatype.DatatypeFactory;
+import java.time.ZonedDateTime;
+
+import static eu.europa.ec.fisheries.uvms.subscription.service.util.DateTimeUtil.convertDateToZonedDateTime;
+
+/**
+ * Implementation of {@link SubscriptionDateTimeService}.
+ */
+@ApplicationScoped
+public class SubscriptionDateTimeServiceImpl implements SubscriptionDateTimeService {
+
+	private DatatypeFactory datatypeFactory;
+
+	@Inject
+	public SubscriptionDateTimeServiceImpl(DatatypeFactory datatypeFactory){
+		this.datatypeFactory = datatypeFactory;
+	}
+
+	/**
+	 * Constructor for frameworks.
+	 */
+	@SuppressWarnings("unused")
+	SubscriptionDateTimeServiceImpl(){
+		//NOOP
+	}
+
+	@Override
+	public ZonedDateTime calculateStartDate(SubscriptionOutput output, ZonedDateTime endDate) {
+		return output.getQueryPeriod() != null ?
+				convertDateToZonedDateTime(output.getQueryPeriod().getStartDate()) : endDate.minus(output.getHistory(), output.getHistoryUnit().getTemporalUnit());
+	}
+
+	@Override
+	public ZonedDateTime calculateEndDate(SubscriptionOutput output,String occurrence) {
+		ZonedDateTime endDate;
+		if (output.getQueryPeriod() != null) {
+			endDate = convertDateToZonedDateTime(output.getQueryPeriod().getEndDate());
+		}
+		else{
+			endDate = datatypeFactory.newXMLGregorianCalendar(occurrence).toGregorianCalendar().toZonedDateTime();
+		}
+		return endDate;
+	}
+
+}

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractorTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractorTest.java
@@ -47,6 +47,7 @@ import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntit
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.AssetPageRetrievalMessage;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.SubscriptionSender;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.asset.AssetSender;
@@ -59,6 +60,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -83,6 +85,10 @@ class ManualSubscriptionCommandFromMessageExtractorTest {
     @Produces
     @Mock
     private AssetSender assetSender;
+
+    @Produces
+    @Mock
+    private AreaFilterComponent areaFilterComponent;
 
     @Produces
     @ApplicationScoped
@@ -118,6 +124,8 @@ class ManualSubscriptionCommandFromMessageExtractorTest {
         when(subscriptionFinder.findSubscriptionById(500L)).thenReturn(subscriptionEntity);
         AssetPageRetrievalCommand assetPageRetrievalCommand = new AssetPageRetrievalCommand(messageForQueue, subscriptionSender);
         when(triggerCommandsFactory.createAssetPageRetrievalCommand(any())).thenReturn(assetPageRetrievalCommand);
+        //skip area filtering
+        when(areaFilterComponent.filterAssetsBySubscriptionAreas(ArgumentMatchers.any())).thenAnswer(i-> ((List<?>) i.getArguments()[0]).stream());
         Stream<Command> result = sut.extractCommands(AssetPageRetrievalMessage.encodeMessage(receivedMessageFromQueue), null);
 
         assertNotNull(result);
@@ -164,6 +172,8 @@ class ManualSubscriptionCommandFromMessageExtractorTest {
         AssetPageRetrievalCommand assetPageRetrievalCommand = new AssetPageRetrievalCommand(assetPageRetrievalMessage, subscriptionSender);
         when(triggerCommandsFactory.createAssetPageRetrievalCommand(any())).thenReturn(assetPageRetrievalCommand);
         when(assetSender.findAssetIdentifiersByAssetGroupGuid(assetGroupName, dateTimeService.getNowAsDate(), pageNumber, pageSize)).thenReturn(groupAssets);
+        //skip area filtering
+        when(areaFilterComponent.filterAssetsBySubscriptionAreas(ArgumentMatchers.any())).thenAnswer(i-> ((List<?>) i.getArguments()[0]).stream());
         Stream<Command> result = sut.extractCommands(encodedMessageFromQueue, null);
 
         assertNotNull(result);

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractorTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractorTest.java
@@ -47,6 +47,7 @@ import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntit
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.AssetPageRetrievalMessage;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.SubscriptionSender;
 import eu.europa.ec.fisheries.uvms.subscription.service.messaging.asset.AssetSender;
@@ -59,6 +60,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -83,6 +85,10 @@ class ScheduledSubscriptionCommandFromMessageExtractorTest {
     @Produces
     @Mock
     private AssetSender assetSender;
+
+    @Produces
+    @Mock
+    private AreaFilterComponent areaFilterComponent;
 
     @Produces
     @ApplicationScoped
@@ -118,6 +124,8 @@ class ScheduledSubscriptionCommandFromMessageExtractorTest {
         when(subscriptionFinder.findSubscriptionById(500L)).thenReturn(subscriptionEntity);
         AssetPageRetrievalCommand assetPageRetrievalCommand = new AssetPageRetrievalCommand(messageForQueue, subscriptionSender);
         when(triggerCommandsFactory.createAssetPageRetrievalCommand(any())).thenReturn(assetPageRetrievalCommand);
+        //skip area filtering
+        when(areaFilterComponent.filterAssetsBySubscriptionAreas(ArgumentMatchers.any())).thenAnswer(i-> ((List<?>) i.getArguments()[0]).stream());
         Stream<Command> result = sut.extractCommands(AssetPageRetrievalMessage.encodeMessage(receivedMessageFromQueue), null);
 
         assertNotNull(result);
@@ -164,6 +172,8 @@ class ScheduledSubscriptionCommandFromMessageExtractorTest {
         AssetPageRetrievalCommand assetPageRetrievalCommand = new AssetPageRetrievalCommand(assetPageRetrievalMessage, subscriptionSender);
         when(triggerCommandsFactory.createAssetPageRetrievalCommand(any())).thenReturn(assetPageRetrievalCommand);
         when(assetSender.findAssetIdentifiersByAssetGroupGuid(assetGroupName, dateTimeService.getNowAsDate(), pageNumber, pageSize)).thenReturn(groupAssets);
+        //skip area filtering
+        when(areaFilterComponent.filterAssetsBySubscriptionAreas(ArgumentMatchers.any())).thenAnswer(i-> ((List<?>) i.getArguments()[0]).stream());
         Stream<Command> result = sut.extractCommands(encodedMessageFromQueue, null);
 
         assertNotNull(result);

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeServiceImplTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/util/SubscriptionDateTimeServiceImplTest.java
@@ -1,0 +1,94 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.xml.datatype.DatatypeFactory;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Date;
+
+import eu.europa.ec.fisheries.uvms.commons.domain.DateRange;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
+import eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionTimeUnit;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link SubscriptionDateTimeServiceImpl}.
+ */
+@EnableAutoWeld
+class SubscriptionDateTimeServiceImplTest {
+
+	@Inject
+	private SubscriptionDateTimeServiceImpl sut;
+
+	@Produces
+	DatatypeFactory getDatatypeFactory() throws Exception {
+		return DatatypeFactory.newInstance();
+	}
+
+	@Test
+	void testCalculateStartDateWithQueryPeriod() {
+		SubscriptionOutput output = new SubscriptionOutput();
+		DateRange queryPeriod = new DateRange(d("20200416"), null);
+		output.setQueryPeriod(queryPeriod);
+		ZonedDateTime endDate = DateTimeUtil.convertDateToZonedDateTime(d("20200517"));
+		ZonedDateTime result = sut.calculateStartDate(output, endDate);
+		assertEquals(2020, result.getYear());
+		assertEquals(Month.APRIL, result.getMonth());
+		assertEquals(16, result.getDayOfMonth());
+	}
+
+	@Test
+	void testCalculateStartDateWithoutQueryPeriod() {
+		SubscriptionOutput output = new SubscriptionOutput();
+		output.setHistory(10);
+		output.setHistoryUnit(SubscriptionTimeUnit.DAYS);
+		ZonedDateTime endDate = DateTimeUtil.convertDateToZonedDateTime(d("20200517"));
+		ZonedDateTime result = sut.calculateStartDate(output, endDate);
+		assertEquals(2020, result.getYear());
+		assertEquals(Month.MAY, result.getMonth());
+		assertEquals(7, result.getDayOfMonth());
+	}
+
+	@Test
+	void testCalculateEndDateWithQueryPeriod() {
+		SubscriptionOutput output = new SubscriptionOutput();
+		DateRange queryPeriod = new DateRange(null, d("20200416"));
+		output.setQueryPeriod(queryPeriod);
+		ZonedDateTime result = sut.calculateEndDate(output, "2020-05-17T13:24:35Z");
+		assertEquals(2020, result.getYear());
+		assertEquals(Month.APRIL, result.getMonth());
+		assertEquals(16, result.getDayOfMonth());
+	}
+
+	@Test
+	void testCalculateEndDateWithoutQueryPeriod() {
+		SubscriptionOutput output = new SubscriptionOutput();
+		ZonedDateTime result = sut.calculateEndDate(output, "2020-05-17T13:24:35Z");
+		assertEquals(2020, result.getYear());
+		assertEquals(Month.MAY, result.getMonth());
+		assertEquals(17, result.getDayOfMonth());
+	}
+
+	static Date d(String s) {
+		return Date.from(ZonedDateTime.parse(s + " 00:00:00", DateTimeFormatter.ofPattern("yyyyMMdd HH:mm:ss").withZone(ZoneId.of("UTC"))).toInstant());
+	}
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/JmsMovementClient.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/JmsMovementClient.java
@@ -1,0 +1,72 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateResponse;
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageException;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelException;
+import eu.europa.ec.fisheries.uvms.movement.model.mapper.JAXBMarshaller;
+import eu.europa.ec.fisheries.uvms.subscription.service.messaging.SubscriptionConsumerBean;
+import eu.europa.ec.fisheries.uvms.subscription.service.messaging.SubscriptionProducerBean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+
+/**
+ * JMS implementation of the {@link MovementClient}.
+ */
+@ApplicationScoped
+public class JmsMovementClient implements MovementClient {
+
+    private SubscriptionProducerBean subscriptionProducer;
+    private SubscriptionConsumerBean subscriptionConsumerBean;
+    private Queue movementQueue;
+
+    /**
+     * Injection constructor.
+     *
+     * @param subscriptionProducer The subscription module producer bean
+     * @param subscriptionConsumerBean The subscription module consumer bean
+     * @param movementQueue The movement specific queue created by ManagedObjectsProducer
+     */
+    @Inject
+    public JmsMovementClient(SubscriptionProducerBean subscriptionProducer, SubscriptionConsumerBean subscriptionConsumerBean, @MovementQueue Queue movementQueue) {
+        this.subscriptionProducer = subscriptionProducer;
+        this.subscriptionConsumerBean = subscriptionConsumerBean;
+        this.movementQueue = movementQueue;
+    }
+
+    /**
+     * Constructor for frameworks.
+     */
+    @SuppressWarnings("unused")
+    JmsMovementClient() {
+        // NOOP
+    }
+
+    @Override
+    public FilterGuidListByAreaAndDateResponse filterGuidListForDateByArea(FilterGuidListByAreaAndDateRequest request) {
+        try {
+            String correlationId = subscriptionProducer.sendMessageToSpecificQueue(JAXBMarshaller.marshallJaxBObjectToString(request), movementQueue, subscriptionConsumerBean.getDestination());
+            FilterGuidListByAreaAndDateResponse response = null;
+            if(correlationId != null) {
+                TextMessage textMessage = subscriptionConsumerBean.getMessage(correlationId, TextMessage.class);
+                response = JAXBMarshaller.unmarshallTextMessage(textMessage, FilterGuidListByAreaAndDateResponse.class);
+            }
+            return response;
+        } catch (MessageException | MovementModelException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/ManagedObjectsProducer.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/ManagedObjectsProducer.java
@@ -1,0 +1,33 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.jms.Queue;
+
+/**
+ * Introduces various Movement-related application server objects into CDI.
+ */
+@Dependent
+class ManagedObjectsProducer {
+
+	@Resource(mappedName = "java:/" + MessageConstants.QUEUE_MODULE_MOVEMENT)
+	private Queue movementQueue;
+
+	@Produces @ApplicationScoped @MovementQueue
+	public Queue getMovementQueue() {
+		return movementQueue;
+	}
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementClient.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementClient.java
@@ -1,0 +1,27 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateResponse;
+
+/**
+ * Low-level client to interesting Movement module services.
+ */
+public interface MovementClient {
+
+    /**
+     * Call @{@code FILTER_GUID_LIST_FOR_DATE_BY_AREA}
+     *
+     * @param request The movement module request
+     * @return The movement module response
+     */
+    FilterGuidListByAreaAndDateResponse filterGuidListForDateByArea(FilterGuidListByAreaAndDateRequest request);
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementQueue.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementQueue.java
@@ -1,0 +1,25 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier for injecting the Movement queue.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface MovementQueue {
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSender.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSender.java
@@ -1,0 +1,38 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AreaEntity;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Service for sending messages to Movement.
+ */
+public interface MovementSender {
+
+	/**
+	 * Retrieves a list of guids that according to movement module there had been at least one movement that satisfies
+	 * the requested criteria
+	 * @param guidList The list that will be filterer
+	 * @param startDate The start date
+	 * @param endDate The end date
+	 * @param areas Areas that occurred a movement
+	 * @return The filtered guid list
+	 */
+	List<String> sendFilterGuidListForAreasRequest(
+            List<String> guidList,
+            Date startDate,
+            Date endDate,
+			Collection<AreaEntity> areas);
+
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSenderImpl.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSenderImpl.java
@@ -1,0 +1,74 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.area.v1.AreaType;
+import eu.europa.ec.fisheries.schema.movement.area.v1.GuidListForAreaFilteringQuery;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateResponse;
+import eu.europa.ec.fisheries.schema.movement.module.v1.MovementModuleMethod;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AreaEntity;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link MovementSender}.
+ */
+@ApplicationScoped
+class MovementSenderImpl implements MovementSender {
+
+	private MovementClient movementClient;
+
+	/**
+	 * Injection constructor
+	 *
+	 * @param movementClient The low-level client to the services of the activity module
+	 */
+	@Inject
+	public MovementSenderImpl(MovementClient movementClient) {
+		this.movementClient = movementClient;
+	}
+
+	/**
+	 * Constructor for frameworks.
+	 */
+	@SuppressWarnings("unused")
+	MovementSenderImpl() {
+		// NOOP
+	}
+
+	@Override
+	public List<String> sendFilterGuidListForAreasRequest(List<String> guidList, Date startDate, Date endDate, Collection<AreaEntity> areas) {
+
+		FilterGuidListByAreaAndDateRequest request = new FilterGuidListByAreaAndDateRequest();
+		request.setMethod(MovementModuleMethod.FILTER_GUID_LIST_FOR_DATE_BY_AREA);
+		GuidListForAreaFilteringQuery value = new GuidListForAreaFilteringQuery();
+		value.getGuidList().addAll(guidList);
+		value.setStartDate(startDate);
+		value.setEndDate(endDate);
+		value.getAreas().addAll(areas.stream().map(MovementSenderImpl::toType).collect(Collectors.toList()));
+		request.setQuery(value);
+		FilterGuidListByAreaAndDateResponse response = movementClient.filterGuidListForDateByArea(request);
+		return response != null ? response.getFilteredList() : new ArrayList<>();
+	}
+
+	private static AreaType toType(AreaEntity areaEntity){
+		AreaType areaType = new AreaType();
+		areaType.setAreaId(areaEntity.getGid());
+		areaType.setAreaName(areaEntity.getAreaType().name());
+		return areaType;
+	}
+}

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/filter/AreaFilterComponentImpl.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/filter/AreaFilterComponentImpl.java
@@ -1,0 +1,81 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.subscription.movement.filter;
+
+import eu.europa.ec.fisheries.uvms.subscription.movement.communication.MovementSender;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.filter.AreaFilterComponent;
+import eu.europa.ec.fisheries.uvms.subscription.service.trigger.AssetAndSubscriptionData;
+import eu.europa.ec.fisheries.uvms.subscription.service.util.SubscriptionDateTimeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class AreaFilterComponentImpl implements AreaFilterComponent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AreaFilterComponentImpl.class);
+
+    private MovementSender movementSender;
+    private SubscriptionDateTimeService subscriptionDateTimeService;
+
+    @Inject
+    public AreaFilterComponentImpl(MovementSender movementSender, SubscriptionDateTimeService subscriptionDateTimeService){
+        this.movementSender = movementSender;
+        this.subscriptionDateTimeService = subscriptionDateTimeService;
+    }
+
+    /**
+     * Constructor for frameworks.
+     */
+    @SuppressWarnings("unused")
+    AreaFilterComponentImpl() {
+        // NOOP
+    }
+
+    @Override
+    public Stream<AssetAndSubscriptionData> filterAssetsBySubscriptionAreas(List<AssetAndSubscriptionData> assetAndSubscriptionDataList) {
+        // subscriptionEntity is the same reference for all items in list
+        AssetAndSubscriptionData firstData = assetAndSubscriptionDataList.get(0);
+        SubscriptionEntity subscriptionEntity = firstData.getSubscription();
+
+        if (!Boolean.TRUE.equals(subscriptionEntity.getHasAreas())) {
+            LOG.debug("Not filtering data, areas not selected.");
+            return assetAndSubscriptionDataList.stream();
+        }
+
+        ZonedDateTime endTime = subscriptionDateTimeService.calculateEndDate(subscriptionEntity.getOutput(),firstData.getOccurrenceKeyData());
+        ZonedDateTime startTime = subscriptionDateTimeService.calculateStartDate(subscriptionEntity.getOutput(),endTime);
+
+        Map<String, AssetAndSubscriptionData> assetMapByGuid = assetAndSubscriptionDataList.stream()
+                .collect(Collectors.toMap(a -> a.getAssetEntity().getGuid(), Function.identity()));
+
+        List<String> filteredGuidList = movementSender.sendFilterGuidListForAreasRequest(
+                new ArrayList<>(assetMapByGuid.keySet()),
+                Date.from(startTime.toInstant()),
+                Date.from(endTime.toInstant()),
+                subscriptionEntity.getAreas()
+        );
+
+        return filteredGuidList.stream().map(assetMapByGuid::get);
+    }
+}

--- a/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSenderImplTest.java
+++ b/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/communication/MovementSenderImplTest.java
@@ -1,0 +1,75 @@
+package eu.europa.ec.fisheries.uvms.subscription.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FilterGuidListByAreaAndDateResponse;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AreaEntity;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link MovementSenderImpl}
+ */
+@EnableAutoWeld
+@ExtendWith(MockitoExtension.class)
+class MovementSenderImplTest {
+
+    private static final String GUID_1 = "97a40d34-45ea-11e7-bec7-4c32759615eb";
+    private static final String GUID_2 = "9694463e-45ea-11e7-bec7-4c32759615eb";
+
+    @Produces @Mock
+    private MovementClient movementClient;
+
+    @Inject
+    private MovementSenderImpl sut;
+
+    @Test
+    void testCreateUsingEmptyConstructor() {
+        MovementSender movementSender = new MovementSenderImpl();
+        assertNotNull(movementSender);
+    }
+
+    @Test
+    void testFindReceiverAndDataflowNullEndpoint() {
+
+        final LocalDate todayLD = LocalDate.now();
+        final Instant lastMonth = todayLD.minusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+        final Instant nextMonth = todayLD.plusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+        FilterGuidListByAreaAndDateResponse response = new FilterGuidListByAreaAndDateResponse();
+        response.getFilteredList().add(GUID_1);
+        List<String> guidList = new ArrayList<>();
+        guidList.add(GUID_1);
+        guidList.add(GUID_2);
+        Set<AreaEntity> areas = new HashSet<>();
+        AreaEntity areaEntity1 = new AreaEntity();
+        areaEntity1.setGid(11L);
+        areaEntity1.setAreaType(eu.europa.ec.fisheries.wsdl.subscription.module.AreaType.GFCM);
+        AreaEntity areaEntity2 = new AreaEntity();
+        areaEntity2.setGid(12L);
+        areaEntity2.setAreaType(eu.europa.ec.fisheries.wsdl.subscription.module.AreaType.PORT);
+        areas.add(areaEntity1);
+        areas.add(areaEntity2);
+
+        when(movementClient.filterGuidListForDateByArea(any())).thenReturn(response);
+        List<String> filteredList = sut.sendFilterGuidListForAreasRequest(guidList,Date.from(lastMonth),Date.from(nextMonth),areas);
+        assertEquals(GUID_1,filteredList.get(0));
+    }
+}

--- a/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/filter/AreaFilterComponentImplTest.java
+++ b/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/filter/AreaFilterComponentImplTest.java
@@ -1,0 +1,145 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+*/
+package eu.europa.ec.fisheries.uvms.subscription.movement.filter;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.europa.ec.fisheries.uvms.commons.domain.DateRange;
+import eu.europa.ec.fisheries.uvms.subscription.movement.communication.MovementSender;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AreaEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.AssetEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionOutput;
+import eu.europa.ec.fisheries.uvms.subscription.service.trigger.AssetAndSubscriptionData;
+import eu.europa.ec.fisheries.uvms.subscription.service.util.SubscriptionDateTimeService;
+import eu.europa.ec.fisheries.uvms.subscription.service.util.SubscriptionDateTimeServiceImpl;
+import lombok.SneakyThrows;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.xml.datatype.DatatypeFactory;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for the {@link AreaFilterComponentImpl}.
+ */
+@EnableAutoWeld
+@ExtendWith(MockitoExtension.class)
+public class AreaFilterComponentImplTest {
+
+    @Produces
+    @Mock
+    private MovementSender movementSender;
+
+    @Produces
+    @ApplicationScoped
+    private SubscriptionDateTimeService dateTimeService = new SubscriptionDateTimeServiceImpl(dataTypeFactory());
+
+    @Inject
+    private AreaFilterComponentImpl sut;
+
+    @Produces
+    @SneakyThrows
+    DatatypeFactory dataTypeFactory(){
+        return DatatypeFactory.newInstance();
+    }
+
+    @Test
+    void testEmptyConstructor() {
+        AreaFilterComponentImpl sut = new AreaFilterComponentImpl();
+        assertNotNull(sut);
+    }
+
+    @Test
+    void testMakeAreaFilterWithNoAreas(){
+        SubscriptionEntity subscriptionEntity = createSubscriptionEntity(1L,false);
+        AssetEntity assetEntity = createAsset(1L,"TestAsset",UUID.randomUUID().toString());
+        AssetAndSubscriptionData assetAndSubscriptionData = new AssetAndSubscriptionData(assetEntity,subscriptionEntity,null);
+        List<AssetAndSubscriptionData> assetAndSubscriptionDataList = new ArrayList<>();
+        assetAndSubscriptionDataList.add(assetAndSubscriptionData);
+
+        List<AssetAndSubscriptionData> filteredData = sut.filterAssetsBySubscriptionAreas(assetAndSubscriptionDataList).collect(Collectors.toList());
+
+        assertNotNull(filteredData);
+        assertEquals(1, filteredData.size());
+    }
+
+    @Test
+    void testMakeAreaFilterWithSelectedAreas(){
+        SubscriptionEntity subscriptionEntity = createSubscriptionEntity(1L,true);
+        String guid1 = UUID.randomUUID().toString();
+        String guid2 = UUID.randomUUID().toString();
+        AssetEntity assetEntity1 = createAsset(1L,"TestAsset",guid1);
+        AssetEntity assetEntity2 = createAsset(2L,"TestAsset",guid2);
+        AssetAndSubscriptionData assetAndSubscriptionData1 = new AssetAndSubscriptionData(assetEntity1,subscriptionEntity,null);
+        AssetAndSubscriptionData assetAndSubscriptionData2 = new AssetAndSubscriptionData(assetEntity2,subscriptionEntity,null);
+        List<AssetAndSubscriptionData> assetAndSubscriptionDataList = new ArrayList<>();
+        assetAndSubscriptionDataList.add(assetAndSubscriptionData1);
+        assetAndSubscriptionDataList.add(assetAndSubscriptionData2);
+        when(movementSender.sendFilterGuidListForAreasRequest(any(),any(),any(),any())).thenReturn(singletonList(guid1));
+
+        List<AssetAndSubscriptionData> filteredData = sut.filterAssetsBySubscriptionAreas(assetAndSubscriptionDataList).collect(Collectors.toList());
+
+        assertNotNull(filteredData);
+        assertEquals(assetEntity1.getId(), filteredData.get(0).getAssetEntity().getId());
+    }
+
+    private SubscriptionEntity createSubscriptionEntity(Long id,boolean sendRequiredData) {
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId(id);
+        subscriptionEntity.setActive(true);
+        if(sendRequiredData){
+            Set<AreaEntity> areaEntitySet = new HashSet<>(Arrays.asList(mock(AreaEntity.class), mock(AreaEntity.class)));
+            subscriptionEntity.setAreas(areaEntitySet);
+            LocalDate todayLD = LocalDate.now();
+            Instant lastMonth = todayLD.minusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+            Instant today = todayLD.atStartOfDay(ZoneId.systemDefault()).toInstant();
+            DateRange queryPeriod = new DateRange();
+            queryPeriod.setStartDate(Date.from(lastMonth));
+            queryPeriod.setEndDate(Date.from(today));
+            SubscriptionOutput output = new SubscriptionOutput();
+            output.setQueryPeriod(queryPeriod);
+            subscriptionEntity.setOutput(output);
+        }
+        subscriptionEntity.setHasAreas(subscriptionEntity.getAreas() != null && !subscriptionEntity.getAreas().isEmpty());
+        return subscriptionEntity;
+    }
+
+    private AssetEntity createAsset(long id, String name,String guid) {
+        AssetEntity assetEntity = new AssetEntity();
+        assetEntity.setId(id);
+        assetEntity.setGuid(guid);
+        assetEntity.setName(name);
+        return assetEntity;
+    }
+}


### PR DESCRIPTION
Added filtering of selected AssetEntities on SubscriptionBasedCommandFromMessageExtractor through AreaFilterComponent, based on their guid, a date period (start and end date) and subscription areas. 
AreaFilterComponent sends JMS message to movement module with the guid list and the rest args to MovementFiltererBean which receives the request and checks for movements based on the Movementarea.movareaAreaId.areaId for the selected areas and checks if exists Movement with Movement.movementConnect.value = :connectId and the time period for the previous area ids and finally responds with the valid guid list.