### PR TITLE
[UNIONVMS-4703] Stop conditions do not stop scheduled executions

### DIFF
--- a/LIQUIBASE/schema/triggeredsubscription.xml
+++ b/LIQUIBASE/schema/triggeredsubscription.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
 				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 	<changeSet id="UNIONVMS-4466-triggeredsubscription" author="nikospara">
 		<createTable tableName="triggered_subscription">
 			<column name="id" type="BIGINT">
@@ -50,6 +50,26 @@
 
 		<rollback>
 			<dropColumn tableName="triggered_subscription" columnName="effective_from" />
+		</rollback>
+	</changeSet>
+	
+	<changeSet id="UNIONVMS-4703-stop-conditions-revised" author="nikospara">
+		<addColumn tableName="triggered_subscription">
+			<column name="status" type="VARCHAR(8)" afterColumn="active" />
+		</addColumn>
+		<update tableName="triggered_subscription">
+			<column name="status" valueComputed="(CASE WHEN active=TRUE THEN 'ACTIVE' ELSE 'INACTIVE' END)" />
+		</update>
+		<dropColumn tableName="triggered_subscription" columnName="active" />
+
+		<rollback>
+			<addColumn tableName="triggered_subscription">
+				<column name="active" type="BOOLEAN"/>
+			</addColumn>
+			<update tableName="triggered_subscription">
+				<column name="active" valueComputed="(CASE WHEN status='ACTIVE' THEN true ELSE false END)" />
+			</update>
+			<dropColumn tableName="triggered_subscription" columnName="status" />
 		</rollback>
 	</changeSet>
 </databaseChangeLog>

--- a/model/src/main/java/eu/europa/fisheries/uvms/subscription/model/enums/ColumnType.java
+++ b/model/src/main/java/eu/europa/fisheries/uvms/subscription/model/enums/ColumnType.java
@@ -20,9 +20,10 @@ public enum ColumnType {
     CHANNEL("channel"),
     ORGANISATION("organisation"),
     MESSAGETYPE("messageType"),
+    TRIGGERTYPE("triggerType"),
     ID("id");
 
-    private String propertyName;
+    private final String propertyName;
 
     ColumnType(String propertyName) {
         this.propertyName = propertyName;

--- a/model/src/main/java/eu/europa/fisheries/uvms/subscription/model/enums/TriggeredSubscriptionStatus.java
+++ b/model/src/main/java/eu/europa/fisheries/uvms/subscription/model/enums/TriggeredSubscriptionStatus.java
@@ -1,0 +1,20 @@
+package eu.europa.fisheries.uvms.subscription.model.enums;
+
+/**
+ * The status of a triggered subscription.
+ */
+public enum TriggeredSubscriptionStatus {
+	/**
+	 * The triggered subscription is active. Executions should be executed and further executions scheduled as necessary.
+	 */
+	ACTIVE,
+	/**
+	 * The triggered subscription is inactive. Executions should not be executed (there shouldn't be any) or scheduled.
+	 */
+	INACTIVE,
+	/**
+	 * The stop conditions have been met. Any pending executions should be executed, but no more should be scheduled.
+	 * If the start conditions are met again, it transitions back to the active state.
+	 */
+	STOPPED
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/TriggeredSubscriptionServiceImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/TriggeredSubscriptionServiceImpl.java
@@ -9,6 +9,8 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.bean;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
@@ -63,7 +65,7 @@ class TriggeredSubscriptionServiceImpl implements TriggeredSubscriptionService {
 	@Override
 	public Stream<TriggeredSubscriptionEntity> findByStopConditionCriteria(StopConditionCriteria criteria) {
 		TriggeredSubscriptionSearchCriteria searchCriteriaForAreas = new TriggeredSubscriptionSearchCriteria();
-		searchCriteriaForAreas.setActive(Boolean.TRUE);
+		searchCriteriaForAreas.setSingleStatus(ACTIVE);
 		searchCriteriaForAreas.setTriggeredSubscriptionData(Collections.singletonMap("connectId", criteria.getConnectId()));
 		searchCriteriaForAreas.setNotInAreas(criteria.getAreas());
 		searchCriteriaForAreas.setSubscriptionQuitArea(true);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImpl.java
@@ -143,6 +143,8 @@ class SubscriptionDaoImpl implements SubscriptionDao {
                 return subscription.get(SubscriptionEntity_.output).get(SubscriptionOutput_.subscriber).get(SubscriptionSubscriber_.organisationId);
             case MESSAGETYPE:
                 return subscription.get(SubscriptionEntity_.output).get(SubscriptionOutput_.messageType);
+            case TRIGGERTYPE:
+                return subscription.get(SubscriptionEntity_.execution).get(SubscriptionExecution_.triggerType);
             default:
                 return subscription.get(SubscriptionEntity_.id);
         }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionExecutionDao.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionExecutionDao.java
@@ -10,9 +10,12 @@
 package eu.europa.ec.fisheries.uvms.subscription.service.dao;
 
 import java.util.Date;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionExecutionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
 import eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionExecutionStatusType;
 
@@ -52,4 +55,13 @@ public interface SubscriptionExecutionDao {
 	 * @return The executions
 	 */
 	Stream<SubscriptionExecutionEntity> findByTriggeredSubscriptionAndStatus(TriggeredSubscriptionEntity triggeredSubscription, SubscriptionExecutionStatusType status);
+
+	/**
+	 * Find pending executions of the given subscription and having the given data.
+	 *
+	 * @param subscription The subscription
+	 * @param dataCriteria The {@code TriggeredSubscriptionDataEntity} to match with
+	 * @return A possibly empty stream of matching executions
+	 */
+	Stream<SubscriptionExecutionEntity> findPendingBy(SubscriptionEntity subscription, Set<TriggeredSubscriptionDataEntity> dataCriteria);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionExecutionDaoImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionExecutionDaoImpl.java
@@ -14,13 +14,22 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.SetJoin;
+import javax.persistence.criteria.Subquery;
 import java.util.Date;
+import java.util.Set;
 import java.util.stream.Stream;
 
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionExecutionEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.SubscriptionExecutionEntity_;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity_;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity_;
 import eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionExecutionStatusType;
 
 /**
@@ -80,6 +89,38 @@ class SubscriptionExecutionDaoImpl implements SubscriptionExecutionDao {
 		query.where(
 				cb.equal(execution.get(SubscriptionExecutionEntity_.triggeredSubscription), triggeredSubscription),
 				cb.equal(execution.get(SubscriptionExecutionEntity_.status), status)
+		);
+		return em.createQuery(query).getResultList().stream(); // TODO Just stream, when we finally sort out the mess with dependencies that is bringing JPA 1.x
+	}
+
+	@Override
+	public Stream<SubscriptionExecutionEntity> findPendingBy(SubscriptionEntity subscription, Set<TriggeredSubscriptionDataEntity> dataCriteria) {
+		CriteriaBuilder cb = em.getCriteriaBuilder();
+		CriteriaQuery<SubscriptionExecutionEntity> query = cb.createQuery(SubscriptionExecutionEntity.class);
+		Root<SubscriptionExecutionEntity> execution = query.from(SubscriptionExecutionEntity.class);
+
+		Subquery<Number> triggeringsSubquery = query.subquery(Number.class);
+		Root<SubscriptionExecutionEntity> correlatedRoot = triggeringsSubquery.correlate(execution);
+		Join<SubscriptionExecutionEntity, TriggeredSubscriptionEntity> triggeredSubscriptionRoot = correlatedRoot.join(SubscriptionExecutionEntity_.triggeredSubscription);
+
+		Subquery<Number> dataSubquery = triggeringsSubquery.subquery(Number.class);
+		Join<SubscriptionExecutionEntity, TriggeredSubscriptionEntity> triggeredSubscriptionCorrelatedRoot = dataSubquery.correlate(triggeredSubscriptionRoot);
+		SetJoin<TriggeredSubscriptionEntity, TriggeredSubscriptionDataEntity> dataRoot = triggeredSubscriptionCorrelatedRoot.join(TriggeredSubscriptionEntity_.data);
+		dataSubquery.select(cb.literal(1));
+		Predicate[] predicates = dataCriteria.stream()
+				.map(d -> cb.and(cb.equal(dataRoot.get(TriggeredSubscriptionDataEntity_.key), d.getKey()), cb.equal(dataRoot.get(TriggeredSubscriptionDataEntity_.value), d.getValue())))
+				.toArray(Predicate[]::new);
+		dataSubquery.where(cb.or(predicates));
+
+		triggeringsSubquery.select(cb.literal(1))
+				.where(
+						cb.equal(triggeredSubscriptionRoot.get(TriggeredSubscriptionEntity_.subscription), subscription),
+						cb.exists(dataSubquery)
+				);
+
+		query.select(execution).where(
+				cb.equal(execution.get(SubscriptionExecutionEntity_.status), SubscriptionExecutionStatusType.PENDING),
+				cb.exists(triggeringsSubquery)
 		);
 		return em.createQuery(query).getResultList().stream(); // TODO Just stream, when we finally sort out the mess with dependencies that is bringing JPA 1.x
 	}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/domain/TriggeredSubscriptionEntity.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/domain/TriggeredSubscriptionEntity.java
@@ -14,6 +14,8 @@ import static javax.persistence.GenerationType.AUTO;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -26,6 +28,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -63,8 +66,9 @@ public class TriggeredSubscriptionEntity {
 	/**
 	 * This is the inverse of what is referenced as "stop" in the specifications.
 	 */
-	@Column(name="active")
-	private Boolean active;
+	@Enumerated(EnumType.STRING)
+	@Column(name="status")
+	private TriggeredSubscriptionStatus status;
 
 	/**
 	 * Referenced as incoming message id in specifications.

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/domain/search/TriggeredSubscriptionSearchCriteria.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/domain/search/TriggeredSubscriptionSearchCriteria.java
@@ -9,9 +9,11 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.domain.search;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,8 +25,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TriggeredSubscriptionSearchCriteria {
-	private Boolean active;
+	private Set<TriggeredSubscriptionStatus> withStatus;
 	private Boolean subscriptionQuitArea;
 	private Map<String,String> triggeredSubscriptionData;
 	private Set<AreaCriterion> notInAreas;
+
+	public void setSingleStatus(TriggeredSubscriptionStatus singleStatus) {
+		setWithStatus(Collections.singleton(singleStatus));
+	}
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dto/SubscriptionExecutionDto.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dto/SubscriptionExecutionDto.java
@@ -33,6 +33,6 @@ public class SubscriptionExecutionDto {
 
 	private Boolean immediate;
 
-    @Pattern(regexp = "^(?:23|22|21|20|[01][0-9]):[0-5][0-9]$")
+    @Pattern(regexp = "^(?:23|22|21|20|[01]?[0-9]):[0-5][0-9]$")
     private String timeExpression;
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dto/list/SubscriptionListDto.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/dto/list/SubscriptionListDto.java
@@ -19,4 +19,5 @@ public class SubscriptionListDto {
 	private String endpointName;
 	private String channelName;
 	private String messageType;
+	private String triggerType;
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/execution/SubscriptionExecutionService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/execution/SubscriptionExecutionService.java
@@ -20,12 +20,13 @@ import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscrip
  */
 public interface SubscriptionExecutionService {
 	/**
-	 * Save the given entity to persistent store.
+	 * Activate the given execution by saving it to persistent store
+	 * and deactivating previous equivalent executions.
 	 *
 	 * @param entity The entity to save
 	 * @return The saved entity
 	 */
-	SubscriptionExecutionEntity save(SubscriptionExecutionEntity entity);
+	SubscriptionExecutionEntity activate(SubscriptionExecutionEntity entity);
 
 	/**
 	 * Find the ids of any executions that must be activated by the given date.

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/mapper/CustomMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/mapper/CustomMapper.java
@@ -58,7 +58,6 @@ public class CustomMapper {
 
         return resultList.stream().map(subscription -> {
             SubscriptionListDto dto = mapper.asListDto(subscription);
-            Optional.ofNullable(subscription.getOutput()).ifPresent(output -> dto.setMessageType(output.getMessageType().name()));
             Organisation orgDomain = Optional.ofNullable(subscription.getOutput()).map(SubscriptionOutput::getSubscriber).map(SubscriptionSubscriber::getOrganisationId).map(organisationMap::get).orElse(null);
             if (orgDomain != null) {
                 String fullOrgName = StringUtils.isNotEmpty(orgDomain.getParentOrganisation()) ? orgDomain.getParentOrganisation() + " / " + orgDomain.getName() : orgDomain.getName();

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/mapper/SubscriptionMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/mapper/SubscriptionMapper.java
@@ -87,6 +87,8 @@ public interface SubscriptionMapper {
     @Mapping(expression = "java(extractSendersFromDto(dto.getSenders()))", target = "senders")
     void updateEntity(SubscriptionDto dto, @MappingTarget SubscriptionEntity entity);
 
+    @Mapping(source = "output.messageType", target = "messageType")
+    @Mapping(source = "execution.triggerType", target = "triggerType")
     SubscriptionListDto asListDto(SubscriptionEntity entity);
 
     @Named("encodePasswordAsBase64")

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/scheduling/SubscriptionExecutionSchedulerImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/scheduling/SubscriptionExecutionSchedulerImpl.java
@@ -9,8 +9,9 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.scheduling;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.INACTIVE;
 import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -60,7 +61,7 @@ class SubscriptionExecutionSchedulerImpl implements SubscriptionExecutionSchedul
 
 	@Override
 	public Optional<SubscriptionExecutionEntity> scheduleNext(TriggeredSubscriptionEntity triggeredSubscription, SubscriptionExecutionEntity lastExecution) {
-		if (!TRUE.equals(triggeredSubscription.getActive()) || !triggeredSubscription.getSubscription().isActive()) {
+		if (!ACTIVE.equals(triggeredSubscription.getStatus()) || !triggeredSubscription.getSubscription().isActive()) {
 			return finish(triggeredSubscription);
 		}
 		if (lastExecution == null) {
@@ -124,7 +125,7 @@ class SubscriptionExecutionSchedulerImpl implements SubscriptionExecutionSchedul
 	}
 
 	private Optional<SubscriptionExecutionEntity> finish(TriggeredSubscriptionEntity triggeredSubscription) {
-		triggeredSubscription.setActive(false);
+		triggeredSubscription.setStatus(INACTIVE);
 		return Optional.empty();
 	}
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/StopSubscriptionCommand.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/StopSubscriptionCommand.java
@@ -9,6 +9,8 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.STOPPED;
+
 import javax.enterprise.inject.Vetoed;
 
 import eu.europa.ec.fisheries.uvms.subscription.service.bean.Command;
@@ -23,23 +25,20 @@ import eu.europa.ec.fisheries.uvms.subscription.service.execution.SubscriptionEx
 class StopSubscriptionCommand implements Command {
 
 	private final TriggeredSubscriptionService triggeredSubscriptionService;
-	private final SubscriptionExecutionService subscriptionExecutionService;
 	private final StopConditionCriteria stopConditionCriteria;
 
-	public StopSubscriptionCommand(TriggeredSubscriptionService triggeredSubscriptionService, SubscriptionExecutionService subscriptionExecutionService, StopConditionCriteria stopConditionCriteria) {
+	public StopSubscriptionCommand(TriggeredSubscriptionService triggeredSubscriptionService, StopConditionCriteria stopConditionCriteria) {
 		this.triggeredSubscriptionService = triggeredSubscriptionService;
-		this.subscriptionExecutionService = subscriptionExecutionService;
 		this.stopConditionCriteria = stopConditionCriteria;
 	}
 
 	@Override
 	public void execute() {
 		triggeredSubscriptionService.findByStopConditionCriteria(stopConditionCriteria)
-				.peek(subscriptionExecutionService::stopPendingExecutions)
-				.forEach(this::deactivate);
+				.forEach(this::stop);
 	}
 
-	private void deactivate(TriggeredSubscriptionEntity triggeredSubscription) {
-		triggeredSubscription.setActive(false);
+	private void stop(TriggeredSubscriptionEntity triggeredSubscription) {
+		triggeredSubscription.setStatus(STOPPED);
 	}
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionBasedCommandFromMessageExtractor.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionBasedCommandFromMessageExtractor.java
@@ -9,6 +9,8 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
+
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.util.Comparator;
@@ -36,7 +38,9 @@ import eu.europa.ec.fisheries.uvms.subscription.service.util.DateTimeService;
 import eu.europa.ec.fisheries.wsdl.asset.types.VesselIdentifiersWithConnectIdHolder;
 import eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVesselIdentifier;
 
-/* Base abstract class for manual and scheduled subscriptions */
+/**
+ * Base abstract class for manual and scheduled subscriptions.
+ */
 public abstract class SubscriptionBasedCommandFromMessageExtractor implements SubscriptionCommandFromMessageExtractor {
 
     private static final String KEY_CONNECT_ID = "connectId";
@@ -77,6 +81,11 @@ public abstract class SubscriptionBasedCommandFromMessageExtractor implements Su
     public abstract String getEligibleSubscriptionSource();
 
     @Override
+    public Function<TriggeredSubscriptionEntity, Set<TriggeredSubscriptionDataEntity>> getDataForDuplicatesExtractor() {
+        return TRIGGERED_SUBSCRIPTION_DATA_FOR_DUPLICATES;
+    }
+
+    @Override
     public Stream<Command> extractCommands(String representation, SenderCriterion ignoredSenderCriterion) {
         AssetPageRetrievalMessage assetPageRetrievalMessage = AssetPageRetrievalMessage.decodeMessage(representation);
         SubscriptionEntity subscription = subscriptionFinder.findSubscriptionById(assetPageRetrievalMessage.getSubscriptionId());
@@ -106,7 +115,7 @@ public abstract class SubscriptionBasedCommandFromMessageExtractor implements Su
         result.setSource(getEligibleSubscriptionSource());
         result.setCreationDate(dateTimeService.getNowAsDate());
         result.setEffectiveFrom(dateTimeService.getNowAsDate());
-        result.setActive(true);
+        result.setStatus(ACTIVE);
         result.setData(makeTriggeredSubscriptionData(result, assetAndSubscriptionData));
         return result;
     }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionCommandFromMessageExtractor.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/SubscriptionCommandFromMessageExtractor.java
@@ -9,9 +9,13 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import eu.europa.ec.fisheries.uvms.subscription.service.bean.Command;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionDataEntity;
+import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.search.SubscriptionSearchCriteria.SenderCriterion;
 
 /**
@@ -35,4 +39,14 @@ public interface SubscriptionCommandFromMessageExtractor {
 	 * @return A possibly empty but never null stream of commands to execute in order to process this message
 	 */
 	Stream<Command> extractCommands(String representation, SenderCriterion senderCriterion);
+
+	/**
+	 * Return a function that can extract the {@link TriggeredSubscriptionDataEntity} that are important for
+	 * comparing triggered subscriptions for equivalence.
+	 * This can be used to identify duplicate triggerings of a subscription, so as to cancel the second or
+	 * identify duplicate executions.
+	 *
+	 * @return The equivalence function
+	 */
+	Function<TriggeredSubscriptionEntity, Set<TriggeredSubscriptionDataEntity>> getDataForDuplicatesExtractor();
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerCommandsFactoryImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerCommandsFactoryImpl.java
@@ -66,7 +66,7 @@ class TriggerCommandsFactoryImpl implements TriggerCommandsFactory {
 
 	@Override
 	public Command createStopSubscriptionCommand(StopConditionCriteria stopConditionCriteria) {
-		return new StopSubscriptionCommand(triggeredSubscriptionService, subscriptionExecutionService, stopConditionCriteria);
+		return new StopSubscriptionCommand(triggeredSubscriptionService, stopConditionCriteria);
 	}
 
 	@Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerSubscriptionCommand.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerSubscriptionCommand.java
@@ -48,7 +48,7 @@ class TriggerSubscriptionCommand implements Command {
 				.filter(this::notAlreadyTriggered)
 				.map(triggeredSubscriptionService::save)
 				.flatMap(subscriptionExecutionScheduler::scheduleNext)
-				.ifPresent(subscriptionExecutionService::save);
+				.ifPresent(subscriptionExecutionService::activate);
 	}
 
 	private boolean notAlreadyTriggered(TriggeredSubscriptionEntity triggeredSubscription) {

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/TriggeredSubscriptionServiceImplTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/TriggeredSubscriptionServiceImplTest.java
@@ -9,6 +9,7 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.bean;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,6 +24,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -100,7 +102,7 @@ public class TriggeredSubscriptionServiceImplTest {
 		TriggeredSubscriptionSearchCriteria areaCriteria = areaCriteriaCaptor.getValue();
 		assertEquals(CONNECT_ID1, areaCriteria.getTriggeredSubscriptionData().get("connectId"));
 		assertEquals(criteria.getAreas(), areaCriteria.getNotInAreas());
-		assertTrue(areaCriteria.getActive());
+		assertEquals(EnumSet.of(ACTIVE), areaCriteria.getWithStatus());
 		assertTrue(areaCriteria.getSubscriptionQuitArea());
 	}
 }

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImplTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImplTest.java
@@ -187,18 +187,17 @@ public class SubscriptionDaoImplTest extends BaseSubscriptionInMemoryTest {
 
     @ParameterizedTest
     @MethodSource("queryParametersWithOrderingAsc")
-    public void testListSubscriptionWithOrderingAsc(SubscriptionListQuery query, long firstResultId, long lastResultId){
-        List<SubscriptionEntity> subscriptionEntities = sut.listSubscriptions(query);
-        assertTrue(subscriptionEntities.size() >= 2);
-        assertEquals(firstResultId, subscriptionEntities.get(0).getId());
-        assertEquals(lastResultId, subscriptionEntities.get(subscriptionEntities.size()-1).getId());
+    public void testListSubscriptionWithOrderingAsc(SubscriptionListQuery query, Long[] expectedResultIds) {
+        List<Long> resultIds = sut.listSubscriptions(query).stream().map(SubscriptionEntity::getId).collect(Collectors.toList());
+        assertEquals(Arrays.asList(expectedResultIds), resultIds);
     }
 
-    protected static Stream<Arguments> queryParametersWithOrderingAsc(){
+    protected static Stream<Arguments> queryParametersWithOrderingAsc() {
         return Stream.of(
-                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.NAME, null), 1L, 4L),
-                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.DESCRIPTION, null), 1L, 4L),
-                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.MESSAGETYPE, null), 2L, 4L)
+                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.NAME, null), new Long[] {1L, 2L, 3L, 4L}),
+                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.DESCRIPTION, null), new Long[] {1L, 2L, 3L, 4L}),
+                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.MESSAGETYPE, null), new Long[] {2L, 3L, 1L, 4L}),
+                Arguments.of(createQuery(null, null, null, null, null, null, null, null, null, null, DirectionType.ASC, ColumnType.TRIGGERTYPE, null), new Long[] {2L, 3L, 1L, 4L})
         );
     }
 
@@ -892,7 +891,7 @@ public class SubscriptionDaoImplTest extends BaseSubscriptionInMemoryTest {
         String password = sut.getEmailConfigurationPassword(1L);
         em.getTransaction().commit();
         em.clear();
-        assertEquals(null, password);
+        assertNull(password);
     }
 
     @Test

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImplTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/dao/SubscriptionDaoImplTest.java
@@ -21,6 +21,7 @@ import static eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVess
 import static eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVesselIdentifier.ICCAT;
 import static eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVesselIdentifier.IRCS;
 import static eu.europa.fisheries.uvms.subscription.model.enums.SubscriptionVesselIdentifier.UVI;
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -923,7 +924,7 @@ public class SubscriptionDaoImplTest extends BaseSubscriptionInMemoryTest {
         EmailBodyEntity email = new EmailBodyEntity(subscription, "email content");
         sut.createEmailBodyEntity(email);
         TriggeredSubscriptionEntity ts = new TriggeredSubscriptionEntity();
-        ts.setActive(true);
+        ts.setStatus(ACTIVE);
         ts.setEffectiveFrom(new Date());
         ts.setCreationDate(new Date());
         ts.setSubscription(subscription);

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractorTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ManualSubscriptionCommandFromMessageExtractorTest.java
@@ -9,6 +9,7 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -138,7 +139,7 @@ class ManualSubscriptionCommandFromMessageExtractorTest {
         TriggeredSubscriptionEntity triggeredSubscription = triggeredSubscriptionCaptor.getValue();
         assertSame(subscriptionEntity, triggeredSubscription.getSubscription());
         assertNotNull(triggeredSubscription.getCreationDate());
-        assertTrue(triggeredSubscription.getActive());
+        assertEquals(ACTIVE, triggeredSubscription.getStatus());
         assertEquals(SOURCE, triggeredSubscription.getSource());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getCreationDate());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getEffectiveFrom());
@@ -195,7 +196,7 @@ class ManualSubscriptionCommandFromMessageExtractorTest {
         TriggeredSubscriptionEntity triggeredSubscription = triggeredSubscriptionCaptor.getValue();
         assertSame(subscriptionEntity, triggeredSubscription.getSubscription());
         assertNotNull(triggeredSubscription.getCreationDate());
-        assertTrue(triggeredSubscription.getActive());
+        assertEquals(ACTIVE, triggeredSubscription.getStatus());
         assertEquals(SOURCE, triggeredSubscription.getSource());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getCreationDate());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getEffectiveFrom());

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractorTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/ScheduledSubscriptionCommandFromMessageExtractorTest.java
@@ -9,6 +9,7 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -138,7 +139,7 @@ class ScheduledSubscriptionCommandFromMessageExtractorTest {
         TriggeredSubscriptionEntity triggeredSubscription = triggeredSubscriptionCaptor.getValue();
         assertSame(subscriptionEntity, triggeredSubscription.getSubscription());
         assertNotNull(triggeredSubscription.getCreationDate());
-        assertTrue(triggeredSubscription.getActive());
+        assertEquals(ACTIVE, triggeredSubscription.getStatus());
         assertEquals(SOURCE, triggeredSubscription.getSource());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getCreationDate());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getEffectiveFrom());
@@ -195,7 +196,7 @@ class ScheduledSubscriptionCommandFromMessageExtractorTest {
         TriggeredSubscriptionEntity triggeredSubscription = triggeredSubscriptionCaptor.getValue();
         assertSame(subscriptionEntity, triggeredSubscription.getSubscription());
         assertNotNull(triggeredSubscription.getCreationDate());
-        assertTrue(triggeredSubscription.getActive());
+        assertEquals(ACTIVE, triggeredSubscription.getStatus());
         assertEquals(SOURCE, triggeredSubscription.getSource());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getCreationDate());
         assertEquals(Date.from(NOW.toInstant(ZoneOffset.UTC)), triggeredSubscription.getEffectiveFrom());

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/StopSubscriptionCommandTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/StopSubscriptionCommandTest.java
@@ -9,15 +9,15 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.service.trigger;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.STOPPED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
 
 import eu.europa.ec.fisheries.uvms.subscription.service.bean.TriggeredSubscriptionService;
 import eu.europa.ec.fisheries.uvms.subscription.service.domain.TriggeredSubscriptionEntity;
-import eu.europa.ec.fisheries.uvms.subscription.service.execution.SubscriptionExecutionService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,17 +32,13 @@ public class StopSubscriptionCommandTest {
 	@Mock
 	private TriggeredSubscriptionService triggeredSubscriptionService;
 
-	@Mock
-	private SubscriptionExecutionService subscriptionExecutionService;
-
 	@Test
 	void testExecute() {
 		StopConditionCriteria stopConditionCriteria = new StopConditionCriteria();
 		TriggeredSubscriptionEntity triggeredSubscription = new TriggeredSubscriptionEntity();
-		triggeredSubscription.setActive(true);
+		triggeredSubscription.setStatus(ACTIVE);
 		when(triggeredSubscriptionService.findByStopConditionCriteria(stopConditionCriteria)).thenReturn(Stream.of(triggeredSubscription));
-		new StopSubscriptionCommand(triggeredSubscriptionService, subscriptionExecutionService, stopConditionCriteria).execute();
-		verify(subscriptionExecutionService).stopPendingExecutions(triggeredSubscription);
-		assertFalse(triggeredSubscription.getActive());
+		new StopSubscriptionCommand(triggeredSubscriptionService, stopConditionCriteria).execute();
+		assertEquals(STOPPED, triggeredSubscription.getStatus());
 	}
 }

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerSubscriptionCommandTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/trigger/TriggerSubscriptionCommandTest.java
@@ -62,7 +62,7 @@ public class TriggerSubscriptionCommandTest {
 		verify(triggeredSubscriptionService).isDuplicate(triggeredSubscription, DATA_FOR_DUPLICATES);
 		verify(triggeredSubscriptionService).save(triggeredSubscription);
 		verify(subscriptionExecutionScheduler).scheduleNext(triggeredSubscription);
-		verify(subscriptionExecutionService).save(subscriptionExecution);
+		verify(subscriptionExecutionService).activate(subscriptionExecution);
 	}
 
 	@Test

--- a/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/trigger/MovementSubscriptionCommandFromMessageExtractor.java
+++ b/subscription-movement/src/main/java/eu/europa/ec/fisheries/uvms/subscription/movement/trigger/MovementSubscriptionCommandFromMessageExtractor.java
@@ -9,6 +9,8 @@
  */
 package eu.europa.ec.fisheries.uvms.subscription.movement.trigger;
 
+import static eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus.ACTIVE;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
@@ -107,6 +109,11 @@ public class MovementSubscriptionCommandFromMessageExtractor implements Subscrip
 	}
 
 	@Override
+	public Function<TriggeredSubscriptionEntity, Set<TriggeredSubscriptionDataEntity>> getDataForDuplicatesExtractor() {
+		return TRIGGERED_SUBSCRIPTION_DATA_FOR_DUPLICATES;
+	}
+
+	@Override
 	public Stream<Command> extractCommands(String representation, SenderCriterion senderCriterion) {
 		return Stream.of(unmarshal(representation))
 				.filter(message -> message.getResponse() == SimpleResponse.OK)
@@ -159,7 +166,7 @@ public class MovementSubscriptionCommandFromMessageExtractor implements Subscrip
 		result.setSubscription(input.getSubscription());
 		result.setSource(SOURCE);
 		result.setCreationDate(dateTimeService.getNowAsDate());
-		result.setActive(true);
+		result.setStatus(ACTIVE);
 		result.setEffectiveFrom(input.getMovement().getPositionTime());
 		result.setData(makeTriggeredSubscriptionData(result, input));
 		return result;

--- a/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/trigger/MovementSubscriptionCommandFromMessageExtractorTest.java
+++ b/subscription-movement/src/test/java/eu/europa/ec/fisheries/uvms/subscription/movement/trigger/MovementSubscriptionCommandFromMessageExtractorTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -50,6 +49,7 @@ import eu.europa.ec.fisheries.uvms.subscription.service.domain.search.AreaCriter
 import eu.europa.ec.fisheries.uvms.subscription.service.trigger.StopConditionCriteria;
 import eu.europa.ec.fisheries.uvms.subscription.service.trigger.TriggerCommandsFactory;
 import eu.europa.fisheries.uvms.subscription.model.enums.TriggerType;
+import eu.europa.fisheries.uvms.subscription.model.enums.TriggeredSubscriptionStatus;
 import eu.europa.fisheries.uvms.subscription.model.exceptions.MessageFormatException;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
@@ -158,7 +158,7 @@ public class MovementSubscriptionCommandFromMessageExtractorTest {
 		TriggeredSubscriptionEntity triggeredSubscription = triggeredSubscriptionCaptor.getValue();
 		assertSame(subscription, triggeredSubscription.getSubscription());
 		assertNotNull(triggeredSubscription.getCreationDate());
-		assertTrue(triggeredSubscription.getActive());
+		assertEquals(TriggeredSubscriptionStatus.ACTIVE, triggeredSubscription.getStatus());
 		assertEquals(NOW, triggeredSubscription.getCreationDate());
 		assertEquals(Date.from(LocalDateTime.of(2017,3,4,17,39).toInstant(ZoneOffset.UTC)), triggeredSubscription.getEffectiveFrom());
 		@SuppressWarnings("unchecked")


### PR DESCRIPTION
Link to issue: [UNIONVMS-4703](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/UNIONVMS-4703)

This introduces a change to how stop conditions are applied: already scheduled executions are not stopped, rather they are executed.