### PR TITLE
[UNIONVMS-4726] Fixed scheduling a subscription to be executed immediately

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBean.java
@@ -418,6 +418,9 @@ class SubscriptionServiceBean implements SubscriptionService {
 
     private Date calculateNextScheduledExecutionDate(SubscriptionEntity subscriptionEntity) {
         Instant date = dateTimeService.getNowAsInstant();
+        if(TRUE.equals(subscriptionEntity.getExecution().getImmediate())) {
+            return Date.from(date);
+        }
         // we need to adjust the requestedTime to
         // the next occurrence of timeExpression, which might be tomorrow
         LocalTime time = LocalTime.parse(subscriptionEntity.getExecution().getTimeExpression(), TIME_EXPRESSION_FORMAT);

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/subscription/service/bean/SubscriptionServiceBeanTest.java
@@ -338,6 +338,20 @@ public class SubscriptionServiceBeanTest {
 	}
 
 	@Test
+	void testCreateImmediatelyScheduledSubscription() {
+		SubscriptionDto dto = SubscriptionTestHelper.createSubscriptionDto( SUBSCR_ID, SUBSCR_NAME, Boolean.TRUE, OutgoingMessageType.FA_QUERY, false,
+				ORGANISATION_ID, ENDPOINT_ID, CHANNEL_ID, true, 1, SubscriptionTimeUnit.DAYS, true, TriggerType.SCHEDULER, 1, SubscriptionTimeUnit.DAYS, "12:00", new Date(), new Date());
+		dto.getExecution().setImmediate(Boolean.TRUE);
+		dateTimeService.setNow(LocalDateTime.now());
+		when(subscriptionDAO.createEntity(any())).thenAnswer(iom -> iom.getArgument(0));
+		sut.create(dto);
+		ArgumentCaptor<SubscriptionEntity> captor = ArgumentCaptor.forClass(SubscriptionEntity.class);
+		verify(subscriptionDAO).createEntity(captor.capture());
+		SubscriptionEntity en = captor.getValue();
+		assertEquals(dateTimeService.getNowAsDate(),en.getExecution().getNextScheduledExecution());
+	}
+	
+	@Test
 	void testCreateWithInvalidArgumentsAndMessageTypePOSITION() {
 		SubscriptionDto dto = SubscriptionTestHelper.createSubscriptionDto(SUBSCR_ID, SUBSCR_NAME, Boolean.TRUE, OutgoingMessageType.POSITION, false,
 				ORGANISATION_ID, ENDPOINT_ID, CHANNEL_ID, true, 1, SubscriptionTimeUnit.DAYS, true, TriggerType.SCHEDULER, 1, SubscriptionTimeUnit.DAYS, "12:00", new Date(), new Date());


### PR DESCRIPTION
- Calculating (method calculateNextScheduledExecutionDate on SubscriptionServiceBean) next scheduled execution date will return current time if immediate execution is true
- Added missing Date nextScheduledExecution on SubscriptionExecutionDto
- Added test case on SubscriptionServiceBeanTest